### PR TITLE
Pass request options to Pwned

### DIFF
--- a/lib/unpwn.rb
+++ b/lib/unpwn.rb
@@ -6,24 +6,26 @@ require "pwned"
 
 # Unpwn.pwned? tells you if a password should be rejected.
 class Unpwn
+  attr_reader :min, :max, :request_options
 
-  def initialize(min: 8, max: nil)
+  def initialize(min: 8, max: nil, request_options: nil)
     raise ArgumentError if min && min < 8
     raise ArgumentError if max && max < 64
 
     @min = min
     @max = max
+    @request_options = request_options || {}
   end
 
   def acceptable?(password)
-    return false if @min && password.size < @min
-    return false if @max && password.size > @max
+    return false if min && password.size < min
+    return false if max && password.size > max
 
     !pwned?(password)
   end
 
   def pwned?(password)
-    bloom.include?(password) || Pwned.pwned?(password)
+    bloom.include?(password) || Pwned.pwned?(password, request_options)
   end
 
   def bloom

--- a/spec/unpwn_spec.rb
+++ b/spec/unpwn_spec.rb
@@ -29,13 +29,18 @@ RSpec.describe Unpwn do
     end
 
     it "is false when in the pwned API" do
-      expect(Pwned).to receive(:pwned?).with("merge mad basic brake").and_return(true)
+      expect(Pwned).to receive(:pwned?).with("merge mad basic brake", {}).and_return(true)
       expect(Unpwn.new.acceptable?("merge mad basic brake")).to be false
     end
 
     it "is true when not in the pwned API" do
-      expect(Pwned).to receive(:pwned?).with("merge mad basic brake").and_return(false)
+      expect(Pwned).to receive(:pwned?).with("merge mad basic brake", {}).and_return(false)
       expect(Unpwn.new.acceptable?("merge mad basic brake")).to be true
+    end
+
+    it "passes request options to pwned" do
+      expect(Pwned).to receive(:pwned?).with("merge mad basic brake", { read_timeout: 5 }).and_return(false)
+      Unpwn.new(request_options: { read_timeout: 5 }).acceptable?("merge mad basic brake")
     end
   end
 end


### PR DESCRIPTION
A quick fix to allow request options (like `read_timeout`) to be passed down to Pwned.

I wasn't sure if you prefer keyword or regular arguments, so if you want the API to be tweaked I'm quite open to it…